### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,9 @@ name: E2E Test
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/mikefrancis/mikefrancis.dev/security/code-scanning/1](https://github.com/mikefrancis/mikefrancis.dev/security/code-scanning/1)

In general, the problem is fixed by explicitly specifying a minimal `permissions` block for the workflow or for each job, instead of relying on the repository’s default `GITHUB_TOKEN` permissions. For a simple E2E test workflow that only checks out code and runs Cypress tests, `contents: read` is typically sufficient, since the job only needs to read the repository and does not need to write to issues, pull requests, or contents.

The best way to fix this specific workflow without changing its behavior is to add a `permissions:` block at the root of the workflow (so it applies to all jobs) with `contents: read`. This satisfies CodeQL’s recommendation while keeping the workflow’s functionality intact. Concretely, in `.github/workflows/e2e.yml`, insert a `permissions:` section after the `on:` block (after line 5) and before `concurrency:`. No extra imports or methods are needed; GitHub Actions natively supports the `permissions` key in workflow YAML files.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
